### PR TITLE
Audit and reorganize documentation; surface API vs local mode choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,50 +6,41 @@
 
 An AI-powered CLI that does two things:
 
-1. **Generates architectural wikis** with source code traceability (`file:line` references)
-2. **Works as an agentic coding assistant** like Claude Code
+1. **Generates architectural wikis** with source traceability (`file:line` references), Mermaid diagrams, and an optional interactive static site
+2. **Works as an agentic coding assistant** with semantic (RAG) search over your codebase
 
 **Built with [buildanagentworkshop.com](https://buildanagentworkshop.com)**
 
 ---
 
-## Two Ways to Use SemanticWiki
+## Choose Your Mode: Cloud or Local
 
-### 1. Generate Documentation (`semanticwiki generate`)
+SemanticWiki can generate documentation three ways. **Pick one before you start** — it determines whether you need an API key at all.
 
-Point SemanticWiki at any codebase and get a complete architectural wiki:
+| Mode | Flag | Requires | Billing | Best for |
+|------|------|----------|---------|----------|
+| **Claude Code** (default) | _none_ | Claude Code installed + credits | Claude Code account | Existing Claude Code users |
+| **Direct API** | `--direct-api` | `ANTHROPIC_API_KEY` | Your Anthropic API credits | Most users with an API key |
+| **Fully local** | `--full-local` | Capable hardware (see below) | **Free** — no API key, no cloud | Privacy, air-gapped, zero-cost runs |
 
 ```bash
+# Cloud, via Claude Code subprocess (default)
 semanticwiki generate -r ./my-project --site
+
+# Cloud, directly against the Anthropic API with your key
+semanticwiki generate -r ./my-project --site --direct-api
+
+# 100% local — no API key, nothing leaves your machine
+semanticwiki generate -r ./my-project --site --full-local
 ```
 
-This creates:
-- **Architecture Overview** with Mermaid diagrams
-- **Module Documentation** with source traceability
-- **Data Flow Documentation**
-- **Getting Started Guides**
-- **Interactive static site** with search, keyboard nav, dark mode
+Notes on each mode:
 
-Every concept links directly to source code (`src/auth/jwt.ts:23-67`), so you can navigate from docs to implementation.
+- **Claude Code mode** spawns a Claude Code subprocess and uses its billing. If you hit a "Credit balance is too low" error here, switch to `--direct-api`.
+- **Direct API mode** runs the same agentic loop against the Anthropic API using your `ANTHROPIC_API_KEY` (default model: `claude-sonnet-5`; override with `--model`).
+- **Local mode** downloads a fine-tuned GGUF model (`gpt-oss-20b-semanticwiki`, ~22 GB one-time download) and runs inference on your machine via node-llama-cpp. Recommended: 24 GB VRAM or 32 GB RAM. You can also point it at an existing [Ollama](https://ollama.com) server with `--use-ollama`. See the **[Local Mode Guide](./docs/local-mode.md)** for hardware requirements, tuning, and troubleshooting.
 
-### 2. Agentic Codebase Assistant
-
-Under the hood, SemanticWiki is a full agentic coding assistant powered by Claude. It doesn't just template docs—it:
-
-- **Explores your codebase** using filesystem tools
-- **Searches semantically** via RAG embeddings (FAISS + all-MiniLM-L6-v2)
-- **Reasons about architecture** to identify patterns and relationships
-- **Writes and verifies** documentation with automatic link checking
-
-```bash
-# The agent runs autonomously, reading files, searching code, writing docs
-semanticwiki generate -r ./my-project --verbose
-
-# Continue where you left off—agent resumes with cached context
-semanticwiki continue -r ./my-project --skip-index
-```
-
-The same RAG system that powers documentation generation gives the agent deep, semantic understanding of your codebase—like Claude Code, but with your entire project pre-indexed for instant retrieval.
+In every mode, embeddings and semantic search always run locally — the mode only changes which LLM writes the documentation.
 
 ---
 
@@ -59,349 +50,195 @@ The same RAG system that powers documentation generation gives the agent deep, s
 npm install -g semanticwiki
 ```
 
-## Prerequisites
+**Prerequisites:**
 
-- **Node.js** >= 18.0.0
-- **Anthropic API key** - Get one at [console.anthropic.com](https://console.anthropic.com)
+- Node.js >= 18
+- For cloud modes: an Anthropic API key from [console.anthropic.com](https://console.anthropic.com)
+- For local mode: see the [Local Mode Guide](./docs/local-mode.md)
 
 ---
 
 ## Quick Start
 
-### 1. Set your API key
-
 ```bash
+# 1. Set your API key (skip this step for --full-local)
 export ANTHROPIC_API_KEY=your-api-key-here
+
+# 2. Generate a wiki + interactive site
+semanticwiki generate -r ./my-project --site --direct-api
+
+# Works with GitHub URLs too
+semanticwiki generate -r https://github.com/user/repo --site --direct-api
+
+# 3. View the results
+#    Markdown wiki:    ./wiki/README.md
+#    Interactive site: ./site/index.html  (generated next to the wiki directory)
 ```
 
-### 2. Generate wiki + interactive site
-
-```bash
-# Generate wiki with interactive site in one command
-semanticwiki generate -r ./my-project --site
-
-# Or for a GitHub repository
-semanticwiki generate -r https://github.com/user/repo --site
-```
-
-### 3. View the results
-
-- **Markdown wiki**: Open `wiki/README.md`
-- **Interactive site**: Open `wiki/site/index.html` in your browser
-
-The static site includes search, navigation, keyboard shortcuts, and works offline.
+Tip: run with `-e / --estimate` first for a dry-run time/cost estimate (in local mode this also checks your hardware and shows the recommended model).
 
 ---
 
-## Usage
+## What You Get
 
-### Generate Command
+The generated wiki contains an architecture overview with Mermaid diagrams, per-module documentation, data-flow docs, getting-started guides, and a glossary. Every concept links to specific source locations:
 
-```bash
-# Basic: Generate wiki for current directory
-semanticwiki generate -r .
+```markdown
+The authentication system uses JWT tokens for stateless auth.
 
-# With interactive static site
-semanticwiki generate -r ./my-project --site
-
-# Custom site title and theme
-semanticwiki generate -r ./my-project --site --site-title "My Project Docs" --theme dark
-
-# Generate site only (if wiki already exists)
-semanticwiki generate -r ./my-project --site-only
-
-# Specify output directory
-semanticwiki generate -r ./my-project -o ./docs/architecture
-
-# Focus on a specific subdirectory
-semanticwiki generate -r ./my-project -p src/core
-
-# Verbose output (see what the agent is doing)
-semanticwiki generate -r ./my-project -v
-
-# Estimate time/cost before running (dry run)
-semanticwiki generate -r ./my-project -e
+**Source:** [`src/auth/jwt-provider.ts:23-67`](../../../src/auth/jwt-provider.ts#L23-L67)
 ```
 
-### Continue Command
+With `--site`, you also get a self-contained static site with full-text search (`/`), keyboard navigation, dark/light themes, rendered Mermaid diagrams, and — with `--ai-chat` — an AI assistant that runs entirely in the browser (SmolLM2 via transformers.js, works offline after the first model download).
 
-Resume generation to fix broken links or add missing pages:
+---
+
+## Commands
+
+### `generate` — create a wiki
 
 ```bash
-# Check for and generate missing pages
+semanticwiki generate -r <repo-path-or-url> [options]
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-r, --repo <path/url>` | Repository path or GitHub/GitLab URL (required) | — |
+| `-o, --output <dir>` | Output directory for wiki | `./wiki` |
+| `-c, --config <file>` | Path to `wiki.json` config file | — |
+| `-t, --token <token>` | Access token for private repos | `$GITHUB_TOKEN` |
+| `-m, --model <model>` | Claude model (cloud modes) | `claude-sonnet-5` |
+| `-p, --path <path>` | Focus on a specific directory | — |
+| `-f, --force` | Force regeneration (ignore cache) | — |
+| `-v, --verbose` | Show detailed progress | — |
+| `-e, --estimate` | Estimate time/cost without running | — |
+| `-s, --site` | Also generate the interactive static site | — |
+| `--site-only` | Generate site from existing wiki markdown | — |
+| `--site-title <title>` | Custom site title | `Architecture Wiki` |
+| `--theme <theme>` | Site theme: `light`, `dark`, `auto` | `auto` |
+| `--ai-chat` | Add the in-browser AI chat assistant to the site | — |
+| `--direct-api` | **Mode:** use the Anthropic API directly | — |
+| `--full-local` | **Mode:** run entirely locally, no API key | — |
+| `--max-turns <n>` | Limit agent iterations | `200` |
+| `--skip-index` | Reuse the cached embeddings index | — |
+| `--max-chunks <n>` | Limit indexed chunks (large repos) | unlimited |
+| `--max-results <n>` | Max search results per query | `10` |
+| `--batch-size <n>` | Batched indexing for very large repos | — |
+| `--compact-search` | Truncate search results to save tokens (auto for large repos) | — |
+
+Local-mode-only options (`--local-model`, `--model-path`, `--use-ollama`, `--ollama-host`, `--gpu-layers`, `--context-size`, `--threads`) are documented in the [Local Mode Guide](./docs/local-mode.md).
+
+### `continue` — finish an incomplete wiki
+
+Verifies internal links and generates any missing pages.
+
+```bash
 semanticwiki continue -r ./my-project -o ./wiki
-
-# Just verify (don't generate)
-semanticwiki continue -r ./my-project -o ./wiki --verify-only
-
-# Use cached index for faster iteration
-semanticwiki continue -r ./my-project -o ./wiki --skip-index
+semanticwiki continue -r ./my-project -o ./wiki --verify-only   # check only
+semanticwiki continue -r ./my-project -o ./wiki --skip-index    # faster iteration
 ```
 
-### Search Command
+Also supports `-m/--model`, `--direct-api`, `--max-turns`, `-v`.
 
-Search your wiki from the command line:
+### `verify` — check wiki completeness
 
 ```bash
-# Search wiki content
-semanticwiki search "authentication flow" -w ./wiki
-
-# Hybrid search (keyword + semantic)
-semanticwiki search "how does login work" -w ./wiki --hybrid
+semanticwiki verify -o ./wiki          # human-readable report
+semanticwiki verify -o ./wiki --json   # JSON output; exit code 1 if incomplete
 ```
 
-### MCP Server
+### `update-embeddings` / `update-wiki` — keep docs current
 
-Start an MCP server for AI assistant integration (Claude Desktop, Claude Code):
+After new commits, update the RAG index and then the affected wiki pages:
 
 ```bash
-# Start MCP server for a wiki
-semanticwiki mcp-server -w ./wiki
-
-# With code search (requires RAG index)
-semanticwiki mcp-server -w ./wiki -r ./my-project
+semanticwiki update-embeddings -r ./my-project -o ./wiki          # incremental re-index
+semanticwiki update-embeddings -r ./my-project -o ./wiki --full   # full re-index
+semanticwiki update-wiki -r ./my-project -o ./wiki                # update affected pages
+semanticwiki update-wiki -r ./my-project -o ./wiki --dry-run      # preview only
 ```
 
-Add to Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+(`update-docs` also exists but currently re-runs full generation; prefer the two commands above.)
+
+### `search` — search the wiki or the code index
+
+```bash
+semanticwiki search "authentication flow" -o ./wiki               # search wiki pages
+semanticwiki search "token validation" -o ./wiki --code           # search code (RAG index)
+semanticwiki search "login" -o ./wiki --code -m keyword           # mode: hybrid|vector|keyword
+semanticwiki search "login" -o ./wiki --code --rerank             # cross-encoder reranking
+```
+
+Options: `-o, --output <dir>` (wiki dir, default `./wiki`), `-n, --max-results <n>` (default 10), `-m, --mode <mode>` (default `hybrid`), `--code`, `--rerank`.
+
+### `mcp-server` — expose the wiki to AI assistants
+
+Starts a stdio MCP server with wiki search/Q&A tools for Claude Desktop or Claude Code:
+
+```bash
+semanticwiki mcp-server -o ./wiki                     # wiki tools
+semanticwiki mcp-server -o ./wiki -r ./my-project     # + code search
+```
+
+Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
 ```json
 {
   "mcpServers": {
     "my-wiki": {
       "command": "semanticwiki",
-      "args": ["mcp-server", "-w", "/path/to/wiki"]
+      "args": ["mcp-server", "-o", "/path/to/wiki"]
     }
   }
 }
 ```
 
-### Pack & Unpack
+### `pack` / `unpack` — share portable wiki packages
 
-Create portable wiki packages for sharing:
-
-```bash
-# Create package (includes wiki + RAG index)
-semanticwiki pack -w ./wiki -o ./my-wiki.archiwiki
-
-# Extract package
-semanticwiki unpack -p ./my-wiki.archiwiki -o ./extracted
-
-# Extract wiki only (no RAG index)
-semanticwiki unpack -p ./my-wiki.archiwiki -o ./extracted --wiki-only
-```
-
-### Large Codebase Options
-
-For repositories with 10,000+ files:
+Bundle a wiki (optionally with its RAG index) into a single `.archiwiki` file:
 
 ```bash
-# Limit indexed chunks (reduces memory usage)
-semanticwiki generate -r ./large-project --max-chunks 5000
-
-# Reduce search results per query
-semanticwiki generate -r ./large-project --max-results 5
-
-# Batched processing (for very large repos)
-semanticwiki generate -r ./large-project --batch-size 3000
+semanticwiki pack -o ./wiki -f ./my-wiki.archiwiki    # create (add --no-rag to exclude index)
+semanticwiki unpack ./my-wiki.archiwiki -o ./extracted
+semanticwiki unpack ./my-wiki.archiwiki --info        # inspect without extracting
+semanticwiki unpack ./my-wiki.archiwiki --wiki-only   # skip the RAG index
 ```
 
-### Direct API Mode
+### Coding assistant (default command)
 
-Bypass Claude Code billing and use your API credits directly:
+Without a subcommand, SemanticWiki is a general-purpose coding agent (requires an API key):
 
 ```bash
-# Uses ANTHROPIC_API_KEY directly
-semanticwiki generate -r ./my-project --direct-api
-
-# Combine with skip-index for fast iteration
-semanticwiki generate -r ./my-project --direct-api --skip-index
+semanticwiki "explain the auth flow in this repo"   # one-shot query
+semanticwiki -i                                     # interactive session
+semanticwiki -p "refactor the config loader"       # plan mode: review a plan before executing
 ```
 
-### Debug & Development
+The interactive session supports slash commands (`/help`, `/plan`, `/mcp-add`, custom commands from `.claude/commands/`, skills, and workflows) and loads the target repo's own `CLAUDE.md`.
 
-```bash
-# Skip re-indexing (use cached embeddings)
-semanticwiki generate -r ./my-project --skip-index
+### `config` — API key help
 
-# Limit agent turns (reduces cost)
-semanticwiki generate -r ./my-project --max-turns 50
-```
+`semanticwiki config --show` displays the current API key source. Keys are read from `ANTHROPIC_API_KEY` (or legacy `CLAUDE_API_KEY`), including from a `.env` file in the working directory.
 
 ---
 
-## Command Reference
+## Large Codebases
 
-### `generate` - Create wiki documentation
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `-r, --repo <path/url>` | Repository path or GitHub URL (required) | - |
-| `-o, --output <dir>` | Output directory for wiki | `./wiki` |
-| `-c, --config <file>` | Path to wiki.json config file | - |
-| `-t, --token <token>` | GitHub token for private repos | - |
-| `-m, --model <model>` | Claude model to use | `claude-sonnet-4-20250514` |
-| `-p, --path <path>` | Focus on specific directory | - |
-| `-f, --force` | Force regeneration (ignore cache) | - |
-| `-v, --verbose` | Show detailed progress | - |
-| `-e, --estimate` | Estimate time/cost (dry run) | - |
-| `-s, --site` | Generate interactive static site | - |
-| `--ai-chat` | Add AI chat assistant to site | - |
-| `--site-only` | Generate site only (skip wiki) | - |
-| `--site-title <title>` | Custom site title | Project name |
-| `--theme <theme>` | Site theme: `light`, `dark`, `auto` | `auto` |
-| `--max-chunks <n>` | Limit indexed chunks | unlimited |
-| `--max-results <n>` | Max search results per query | `10` |
-| `--batch-size <n>` | Enable batched processing | - |
-| `--skip-index` | Use cached embeddings index | - |
-| `--max-turns <n>` | Limit agent iterations | `200` |
-| `--direct-api` | Use Anthropic API directly | - |
-
-### `continue` - Resume/fix wiki generation
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `-r, --repo <path>` | Repository path (required) | - |
-| `-o, --output <dir>` | Wiki output directory | `./wiki` |
-| `-m, --model <model>` | Claude model to use | `claude-sonnet-4-20250514` |
-| `-v, --verbose` | Show detailed progress | - |
-| `--verify-only` | Only check, don't generate | - |
-| `--skip-index` | Use cached embeddings index | - |
-| `--direct-api` | Use Anthropic API directly | - |
-| `--max-turns <n>` | Limit agent iterations | `200` |
-
-### `search` - Search wiki content
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `<query>` | Search query (required) | - |
-| `-w, --wiki <dir>` | Wiki directory | `./wiki` |
-| `-n, --limit <n>` | Max results | `10` |
-| `--hybrid` | Use hybrid search (keyword + semantic) | - |
-
-### `mcp-server` - Start MCP server
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `-w, --wiki <dir>` | Wiki directory (required) | - |
-| `-r, --repo <path>` | Repository path (enables code search) | - |
-
-### `pack` - Create wiki package
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `-w, --wiki <dir>` | Wiki directory (required) | - |
-| `-o, --output <file>` | Output package path | `<name>.archiwiki` |
-| `-n, --name <name>` | Package name | wiki folder name |
-| `--no-rag` | Exclude RAG index | - |
-
-### `unpack` - Extract wiki package
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `-p, --package <file>` | Package file (required) | - |
-| `-o, --output <dir>` | Output directory | `.` |
-| `--wiki-only` | Extract wiki only (no RAG index) | - |
-
----
-
-## Static Site Features
-
-When you use `--site`, SemanticWiki generates a fully interactive documentation site:
-
-- **Full-text search** - Instant search across all pages (Cmd/Ctrl+K)
-- **AI Chat Assistant** - Ask questions about your codebase (`--ai-chat`)
-- **Keyboard navigation** - Arrow keys, vim-style (j/k/h/l)
-- **Dark/light mode** - Respects system preference or manual toggle
-- **Table of contents** - Auto-generated from headings
-- **Mobile responsive** - Works on all devices
-- **Offline capable** - No server required, AI runs client-side
-- **Mermaid diagrams** - Rendered automatically
-
-### AI Chat (`--ai-chat`)
-
-Add an interactive AI assistant to your documentation site:
+For repos with 10,000+ files:
 
 ```bash
-semanticwiki generate -r ./my-project --site --ai-chat
+semanticwiki generate -r ./large-project --max-chunks 5000   # cap memory usage
+semanticwiki generate -r ./large-project --batch-size 3000   # batched indexing
+semanticwiki generate -r ./large-project --max-results 5     # smaller search results
 ```
 
-The chat assistant:
-- Runs entirely in the browser (SmolLM2 via transformers.js)
-- Searches your docs semantically to answer questions
-- Works offline after initial model download
-- Includes "codemap" mode for architecture visualization
-
----
-
-## What to Expect
-
-When you run SemanticWiki:
-
-1. **Repository Analysis** - The agent scans your codebase structure
-2. **Semantic Indexing** - Creates embeddings for intelligent code search
-3. **Architecture Discovery** - Identifies patterns, components, and relationships
-4. **Documentation Generation** - Writes markdown pages with diagrams
-5. **Verification Loop** - Checks all links and generates missing pages
-6. **Source Linking** - Every concept links to specific file:line references
-
-### Typical Runtime
-
-| Codebase Size | Approximate Time |
-|---------------|------------------|
-| Small (<50 files) | 1-2 minutes |
-| Medium (50-200 files) | 2-5 minutes |
-| Large (200+ files) | 5-10 minutes |
-
-Use `--estimate` to get a cost/time estimate before running.
-
----
-
-## Example Output
-
-The generated wiki structure:
-
-```
-wiki/
-├── README.md                    # Navigation entry point
-├── architecture/
-│   ├── overview.md              # System architecture + diagrams
-│   └── data-flow.md             # Data flow documentation
-├── components/
-│   └── {module}/
-│       └── index.md             # Per-module documentation
-├── guides/
-│   └── getting-started.md       # Quick start guide
-├── glossary.md                  # Concept index
-└── site/                        # (with --site flag)
-    ├── index.html               # Interactive site entry
-    ├── styles.css
-    └── scripts.js
-```
-
-### Source Traceability Example
-
-Every architectural concept includes clickable source references:
-
-```markdown
-## Authentication Flow
-
-The authentication system uses JWT tokens for stateless auth.
-
-**Source:** [`src/auth/jwt-provider.ts:23-67`](../../../src/auth/jwt-provider.ts#L23-L67)
-
-```typescript
-export class JwtProvider {
-  async generateToken(user: User): Promise<string> {
-    // Token generation logic...
-  }
-}
-```
-```
+When the index exceeds 50k chunks, search automatically switches to fewer results and compact mode. Chunks are prioritized: core directories (`src/`, `lib/`, `app/`) and entry points score highest; tests and vendored code score lowest.
 
 ---
 
 ## Configuration (Optional)
 
-Create a `wiki.json` file in your project root to customize generation:
+Create a `wiki.json` in your project root to customize generation:
 
 ```json
 {
@@ -422,106 +259,46 @@ Create a `wiki.json` file in your project root to customize generation:
 
 ---
 
-## Technical Details
-
-### RAG & Hybrid Search System
-
-SemanticWiki uses a sophisticated retrieval system combining multiple strategies:
-
-- **Chunk size**: 1,500 characters with 200 character overlap
-- **Language-aware boundaries**: Chunks end at logical points (`}`, `};`, `end`)
-- **Embedding model**: `BGE-small-en-v1.5` (384 dimensions, runs locally)
-- **Hybrid search**: BM25 keyword + vector similarity with RRF fusion
-- **Vector search**: FAISS with `IndexFlatIP` for cosine similarity
-- **Incremental updates**: Only re-embeds changed files on subsequent runs
-
-### Chunk Prioritization
-
-For large codebases, chunks are prioritized by importance:
-- Core directories (`src/`, `lib/`, `app/`): +100 points
-- Entry points (`index.*`, `main.*`): +50 points
-- Config files: +30 points
-- Test files: -50 points
-- Vendor/generated code: -100 points
-
----
-
 ## How It Works
 
-SemanticWiki is built with:
-
-- **[Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk)** - Orchestrates the AI agent workflow
-- **RAG (Retrieval Augmented Generation)** - Semantic code search using embeddings
-- **[Model Context Protocol (MCP)](https://modelcontextprotocol.io)** - Tool integration for file operations
-- **Mermaid** - Architecture diagram generation
-- **FAISS** - High-performance vector similarity search
+- **[Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk)** or a hand-rolled tool-use loop (direct API / local modes) orchestrates the agent
+- **RAG system**: AST-aware chunking at logical code boundaries; `BGE-small-en-v1.5` embeddings computed locally via `@huggingface/transformers` (cached in `./.semanticwiki-models`); FAISS vector search with a pure-JS fallback; hybrid BM25 + vector search fused with Reciprocal Rank Fusion; optional cross-encoder reranking
+- **Incremental indexing**: only changed files are re-embedded on subsequent runs (index lives in `<wiki>/.semanticwiki-cache`)
+- **Verification loop**: checks all internal wiki links and generates missing pages
+- **[MCP](https://modelcontextprotocol.io)** for tool integration, **Mermaid** for diagrams
 
 ---
 
 ## Troubleshooting
 
-### "Credit balance is too low" error
-
-Use `--direct-api` to bypass Claude Code's billing check:
-```bash
-semanticwiki generate -r ./my-project --direct-api
-```
-
-### Out of memory on large repos
-
-Limit the indexed chunks:
-```bash
-semanticwiki generate -r ./large-project --max-chunks 5000 --batch-size 3000
-```
-
-### Slow re-runs during development
-
-Skip re-indexing with cached embeddings:
-```bash
-semanticwiki generate -r ./my-project --skip-index
-```
-
-### Missing pages / broken links
-
-Use the continue command to fix:
-```bash
-semanticwiki continue -r ./my-project -o ./wiki
-```
+| Problem | Fix |
+|---------|-----|
+| "Credit balance is too low" | Use `--direct-api` (your API credits) or `--full-local` (free) |
+| No API key and don't want one | Use `--full-local` — see [Local Mode Guide](./docs/local-mode.md) |
+| Out of memory on large repos | `--max-chunks 5000 --batch-size 3000` |
+| Slow re-runs while iterating | `--skip-index` to reuse cached embeddings |
+| Missing pages / broken links | `semanticwiki continue -r ./my-project -o ./wiki` |
+| Local mode issues | See [Local Mode Guide](./docs/local-mode.md#troubleshooting) |
 
 ---
 
 ## Development
 
 ```bash
-# Clone the repo
-git clone https://github.com/your-username/semanticwiki.git
+git clone https://github.com/GhostScientist/semanticwiki.git
 cd semanticwiki
-
-# Install dependencies
 npm install
-
-# Build
-npm run build
-
-# Run locally
-npm start -- generate -r ./my-project
-
-# Watch mode for development
-npm run dev
+npm run build            # compile to dist/
+npm test                 # run tests (vitest)
+npm start -- generate -r ./my-project --verbose
 ```
 
----
-
-## Built With
-
-This project was created using the [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk) at the **Build an Agent Workshop**.
-
-**Learn to build your own AI agents at [buildanagentworkshop.com](https://buildanagentworkshop.com)**
+More docs live in [`docs/`](./docs/README.md).
 
 ---
 
 ## License
 
-MIT License - Copyright (c) 2025 Dakota Kim / reasoning.software (MadWatch LLC)
+MIT License — Copyright (c) 2025 Dakota Kim / reasoning.software (MadWatch LLC)
 
 See [LICENSE](./LICENSE) for full terms. Attribution to Dakota Kim as the original creator is required in all forks and derivative works.

--- a/docs/LOCAL_ONLY_TESTING.md
+++ b/docs/LOCAL_ONLY_TESTING.md
@@ -1,262 +1,92 @@
 # Local Mode Testing Guide
 
-This document provides public GitHub repositories of varying sizes and tech stacks for testing the `--full-local` mode of semanticwiki.
+Maintainer guide: public GitHub repositories of varying sizes and tech stacks for testing `--full-local` mode. For user-facing local mode documentation, see [local-mode.md](./local-mode.md).
 
 ## Test Repositories
 
-### Small Codebases (~100-500 files)
+### Small (~100–500 files)
 
-#### 1. **jq** - Lightweight JSON Processor (C)
-- **URL**: https://github.com/jqlang/jq
-- **Size**: ~300 files
-- **Language**: C
-- **Description**: Command-line JSON processor. Well-structured C codebase with clear architecture.
-- **Test command**:
-  ```bash
-  semanticwiki generate -r https://github.com/jqlang/jq --full-local -o ./wiki-jq
-  ```
+| Repo | Language | Test command |
+|------|----------|--------------|
+| [jq](https://github.com/jqlang/jq) (~300 files) | C | `semanticwiki generate -r https://github.com/jqlang/jq --full-local -o ./wiki-jq` |
+| [httpie](https://github.com/httpie/cli) (~200 files) | Python | `semanticwiki generate -r https://github.com/httpie/cli --full-local -o ./wiki-httpie` |
+| [bat](https://github.com/sharkdp/bat) (~150 files) | Rust | `semanticwiki generate -r https://github.com/sharkdp/bat --full-local -o ./wiki-bat` |
 
-#### 2. **httpie** - HTTP CLI Client (Python)
-- **URL**: https://github.com/httpie/cli
-- **Size**: ~200 files
-- **Language**: Python
-- **Description**: Modern HTTP client for the command line. Clean Python project structure.
-- **Test command**:
-  ```bash
-  semanticwiki generate -r https://github.com/httpie/cli --full-local -o ./wiki-httpie
-  ```
+### Medium (~500–2,000 files)
 
-#### 3. **bat** - A cat Clone with Wings (Rust)
-- **URL**: https://github.com/sharkdp/bat
-- **Size**: ~150 files
-- **Language**: Rust
-- **Description**: Cat clone with syntax highlighting and Git integration.
-- **Test command**:
-  ```bash
-  semanticwiki generate -r https://github.com/sharkdp/bat --full-local -o ./wiki-bat
-  ```
+| Repo | Language | Test command |
+|------|----------|--------------|
+| [GnuCOBOL](https://github.com/OCamlPro/gnucobol) (~1,200 files) | COBOL/C | `semanticwiki generate -r https://github.com/OCamlPro/gnucobol --full-local -o ./wiki-gnucobol` |
+| [ripgrep](https://github.com/BurntSushi/ripgrep) (~800 files) | Rust | `semanticwiki generate -r https://github.com/BurntSushi/ripgrep --full-local -o ./wiki-ripgrep` |
+| [FastAPI](https://github.com/tiangolo/fastapi) (~600 files) | Python | `semanticwiki generate -r https://github.com/tiangolo/fastapi --full-local -o ./wiki-fastapi` |
+| [esbuild](https://github.com/evanw/esbuild) (~1,500 files) | Go | `semanticwiki generate -r https://github.com/evanw/esbuild --full-local -o ./wiki-esbuild` |
 
----
+GnuCOBOL is notable for exercising the COBOL chunking capability.
 
-### Medium Codebases (~500-2000 files)
+### Large (2,000+ files)
 
-#### 4. **GnuCOBOL** - COBOL Compiler (COBOL/C)
-- **URL**: https://github.com/OCamlPro/gnucobol
-- **Size**: ~1,200 files
-- **Language**: COBOL, C
-- **Description**: Free/open-source COBOL compiler. Excellent for testing COBOL parsing.
-- **Why notable**: One of the most actively maintained COBOL projects. Tests the COBOL chunking capability.
-- **Test command**:
-  ```bash
-  semanticwiki generate -r https://github.com/OCamlPro/gnucobol --full-local -o ./wiki-gnucobol
-  ```
+Use `--max-chunks` and/or `-p/--path` to bound the work.
 
-#### 5. **ripgrep** - Fast Search Tool (Rust)
-- **URL**: https://github.com/BurntSushi/ripgrep
-- **Size**: ~800 files
-- **Language**: Rust
-- **Description**: Extremely fast recursive search tool. Well-documented, great architecture.
-- **Test command**:
-  ```bash
-  semanticwiki generate -r https://github.com/BurntSushi/ripgrep --full-local -o ./wiki-ripgrep
-  ```
+| Repo | Language | Test command |
+|------|----------|--------------|
+| [rust-lang/rust](https://github.com/rust-lang/rust) (30,000+ files) | Rust | `semanticwiki generate -r https://github.com/rust-lang/rust --full-local -o ./wiki-rust-std -p library/std` |
+| [Deno](https://github.com/denoland/deno) (~5,000 files) | Rust/TS | `semanticwiki generate -r https://github.com/denoland/deno --full-local -o ./wiki-deno --max-chunks 5000` |
+| [Neovim](https://github.com/neovim/neovim) (~4,000 files) | C/Lua | `semanticwiki generate -r https://github.com/neovim/neovim --full-local -o ./wiki-neovim --max-chunks 4000` |
 
-#### 6. **FastAPI** - Modern Python Web Framework (Python)
-- **URL**: https://github.com/tiangolo/fastapi
-- **Size**: ~600 files
-- **Language**: Python
-- **Description**: Modern, fast web framework for building APIs. Excellent documentation baseline.
-- **Test command**:
-  ```bash
-  semanticwiki generate -r https://github.com/tiangolo/fastapi --full-local -o ./wiki-fastapi
-  ```
+### Enterprise / Mainframe (COBOL/JCL)
 
-#### 7. **esbuild** - Fast JavaScript Bundler (Go)
-- **URL**: https://github.com/evanw/esbuild
-- **Size**: ~1,500 files
-- **Language**: Go
-- **Description**: Extremely fast JavaScript bundler. Clean Go architecture.
-- **Test command**:
-  ```bash
-  semanticwiki generate -r https://github.com/evanw/esbuild --full-local -o ./wiki-esbuild
-  ```
+| Repo | Language | Test command |
+|------|----------|--------------|
+| [AWS CardDemo](https://github.com/aws-samples/aws-mainframe-modernization-carddemo) (~100 files) | COBOL/JCL | `semanticwiki generate -r https://github.com/aws-samples/aws-mainframe-modernization-carddemo --full-local -o ./wiki-carddemo` |
+| [COBOL Programming Course](https://github.com/openmainframeproject/cobol-programming-course) (~200 files) | COBOL/JCL | `semanticwiki generate -r https://github.com/openmainframeproject/cobol-programming-course --full-local -o ./wiki-cobol-course` |
 
----
+CardDemo contains realistic production-like COBOL/CICS patterns.
 
-### Large Codebases (~2000-10000 files)
+## Expected Runtimes
 
-#### 8. **Rust Compiler (rustc)** - Core Library (Rust)
-- **URL**: https://github.com/rust-lang/rust
-- **Size**: ~30,000+ files (use `--path` to focus)
-- **Language**: Rust
-- **Description**: The Rust programming language compiler.
-- **Recommended**: Focus on specific directories
-- **Test command**:
-  ```bash
-  # Focus on the standard library
-  semanticwiki generate -r https://github.com/rust-lang/rust --full-local -o ./wiki-rust-std -p library/std
+With the bundled `gpt-oss-20b-semanticwiki` model on recommended hardware (24 GB VRAM GPU or Apple Silicon with 32 GB+ unified memory):
 
-  # Or focus on the compiler frontend
-  semanticwiki generate -r https://github.com/rust-lang/rust --full-local -o ./wiki-rustc -p compiler/rustc_parse --max-chunks 3000
-  ```
+| Repo size | Expected time |
+|-----------|---------------|
+| Small | ~15–30 min |
+| Medium | ~30–60 min |
+| Large (chunk-capped) | ~2–3 hours |
 
-#### 9. **Deno** - JavaScript/TypeScript Runtime (Rust/TypeScript)
-- **URL**: https://github.com/denoland/deno
-- **Size**: ~5,000 files
-- **Language**: Rust, TypeScript
-- **Description**: Modern JavaScript/TypeScript runtime. Mixed Rust/TS codebase.
-- **Test command**:
-  ```bash
-  semanticwiki generate -r https://github.com/denoland/deno --full-local -o ./wiki-deno --max-chunks 5000
-  ```
-
-#### 10. **Neovim** - Vim-based Text Editor (C/Lua)
-- **URL**: https://github.com/neovim/neovim
-- **Size**: ~4,000 files
-- **Language**: C, Lua
-- **Description**: Modern Vim fork with improved architecture.
-- **Test command**:
-  ```bash
-  semanticwiki generate -r https://github.com/neovim/neovim --full-local -o ./wiki-neovim --max-chunks 4000
-  ```
-
----
-
-### Enterprise/Mainframe Codebases (COBOL/JCL)
-
-#### 11. **AWS CardDemo** - COBOL Sample Application
-- **URL**: https://github.com/aws-samples/aws-mainframe-modernization-carddemo
-- **Size**: ~100 files
-- **Language**: COBOL, JCL
-- **Description**: AWS sample mainframe application for modernization demos. Contains realistic COBOL/CICS patterns.
-- **Why notable**: Official AWS sample with production-like COBOL patterns.
-- **Test command**:
-  ```bash
-  semanticwiki generate -r https://github.com/aws-samples/aws-mainframe-modernization-carddemo --full-local -o ./wiki-carddemo
-  ```
-
-#### 12. **COBOL Programming Course**
-- **URL**: https://github.com/openmainframeproject/cobol-programming-course
-- **Size**: ~200 files
-- **Language**: COBOL, JCL
-- **Description**: Open Mainframe Project's COBOL course materials with sample programs.
-- **Test command**:
-  ```bash
-  semanticwiki generate -r https://github.com/openmainframeproject/cobol-programming-course --full-local -o ./wiki-cobol-course
-  ```
-
----
-
-## Testing Matrix
-
-| Repository | Size | Languages | Expected Time (Local 14B) | Expected Time (Local 7B) |
-|------------|------|-----------|--------------------------|-------------------------|
-| jq | Small | C | ~15-20 min | ~10-15 min |
-| httpie | Small | Python | ~12-18 min | ~8-12 min |
-| bat | Small | Rust | ~15-20 min | ~10-15 min |
-| GnuCOBOL | Medium | COBOL/C | ~45-60 min | ~30-45 min |
-| ripgrep | Medium | Rust | ~30-45 min | ~20-30 min |
-| FastAPI | Medium | Python | ~25-35 min | ~18-25 min |
-| esbuild | Medium | Go | ~40-55 min | ~28-40 min |
-| Deno | Large | Rust/TS | ~2-3 hours | ~1.5-2 hours |
-| Neovim | Large | C/Lua | ~2-3 hours | ~1.5-2 hours |
-| CardDemo | Small | COBOL/JCL | ~20-30 min | ~15-20 min |
-
----
-
-## Hardware Recommendations by Repository Size
-
-### Small Repositories
-- **Minimum**: 8GB RAM, any GPU or CPU-only
-- **Recommended**: 16GB RAM, 6GB+ VRAM
-- **Model**: `qwen2.5-coder-7b-q5` or `qwen2.5-coder-14b-q5`
-
-### Medium Repositories
-- **Minimum**: 16GB RAM, 8GB VRAM
-- **Recommended**: 32GB RAM, 12GB+ VRAM
-- **Model**: `qwen2.5-coder-14b-q5` or `qwen2.5-coder-32b-q4`
-
-### Large Repositories
-- **Minimum**: 32GB RAM, 16GB VRAM
-- **Recommended**: 64GB RAM, 24GB+ VRAM
-- **Model**: `qwen2.5-coder-32b-q4`
-- **Note**: Use `--max-chunks` to limit memory usage
-
----
+CPU-only inference is 3–5x slower. Smaller Ollama models (e.g. `qwen2.5-coder:7b`) are faster but lower quality.
 
 ## Testing Checklist
 
-### Basic Functionality
-- [ ] Model auto-download works on first run
+### Basic functionality
+- [ ] Model auto-download works on first run (with progress bar)
 - [ ] Hardware detection identifies GPU correctly
-- [ ] Model recommendation matches available hardware
-- [ ] Progress bar shows during inference
+- [ ] `--estimate` reports hardware, model status, and time estimates
 - [ ] Wiki pages are generated with source references
 
-### Quality Checks
-- [ ] Generated diagrams render correctly (Mermaid)
-- [ ] Source file:line references are accurate
-- [ ] Cross-references between pages work
+### Quality
+- [ ] Generated Mermaid diagrams render correctly
+- [ ] Source `file:line` references are accurate
+- [ ] Cross-references between pages resolve (`semanticwiki verify`)
 - [ ] Index page lists all generated pages
 
-### Error Handling
+### Error handling
 - [ ] Graceful handling of insufficient memory
-- [ ] Recovery from network errors during download
+- [ ] Recovery from network errors during model download
 - [ ] Proper cleanup on Ctrl+C interrupt
 
-### Ollama Backend (Power Users)
+### Ollama backend
 ```bash
-# Test with Ollama backend
 ollama pull qwen2.5-coder:14b
 semanticwiki generate -r https://github.com/jqlang/jq --full-local --use-ollama -o ./wiki-jq-ollama
 ```
 
----
-
-## Comparing Results
-
-To compare local mode quality with cloud mode:
+## Comparing Local vs Cloud Quality
 
 ```bash
-# Generate with local mode
 semanticwiki generate -r https://github.com/httpie/cli --full-local -o ./wiki-local
-
-# Generate with Claude (requires API key)
 semanticwiki generate -r https://github.com/httpie/cli --direct-api -o ./wiki-cloud
-
-# Compare the outputs
 diff -r ./wiki-local ./wiki-cloud
 ```
 
----
-
 ## Troubleshooting
 
-### Model Download Issues
-```bash
-# Manual download if auto-download fails
-mkdir -p ~/.semanticwiki/models
-wget -O ~/.semanticwiki/models/qwen2.5-coder-14b-instruct-q5_k_m.gguf \
-  "https://huggingface.co/Qwen/Qwen2.5-Coder-14B-Instruct-GGUF/resolve/main/qwen2.5-coder-14b-instruct-q5_k_m.gguf"
-```
-
-### Out of Memory
-```bash
-# Reduce context size
-semanticwiki generate -r <repo> --full-local --context-size 16384
-
-# Use smaller model
-semanticwiki generate -r <repo> --full-local --local-model qwen2.5-coder-7b-q5
-
-# Limit chunks for large repos
-semanticwiki generate -r <repo> --full-local --max-chunks 2000
-```
-
-### Slow Performance
-```bash
-# Check GPU is being used
-semanticwiki generate -r <repo> --full-local --verbose
-
-# Force more GPU layers
-semanticwiki generate -r <repo> --full-local --gpu-layers 40
-```
+See the [Local Mode Guide troubleshooting section](./local-mode.md#troubleshooting) for model download, out-of-memory, and performance fixes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,18 @@
+# SemanticWiki Documentation
+
+Start with the main [README](../README.md) for installation, the cloud-vs-local mode choice, and the full command reference.
+
+## Guides
+
+- **[Local Mode Guide](./local-mode.md)** — run SemanticWiki with no API key: bundled model, hardware requirements, Ollama backend, tuning, troubleshooting
+- **[Local Mode Testing Guide](./LOCAL_ONLY_TESTING.md)** — maintainer checklist and test repositories for exercising `--full-local`
+
+## Plans (historical / forward-looking)
+
+- **[Roadmap](./plans/ROADMAP.md)** — prioritized next features
+- **[Local Mode Plan](./plans/LOCAL_MODE_PLAN.md)** — original design document for local mode (implemented; kept for reference)
+
+## Project-Level Files
+
+- [CHANGELOG](../CHANGELOG.md) — release history
+- [CLAUDE.md](../CLAUDE.md) — codebase guidance for AI coding assistants

--- a/docs/local-mode.md
+++ b/docs/local-mode.md
@@ -1,0 +1,99 @@
+# Local Mode Guide
+
+`--full-local` runs SemanticWiki entirely on your machine: no API key, no cloud calls, no per-token cost. Embeddings already run locally in every mode — local mode additionally replaces the cloud LLM with a local one.
+
+```bash
+semanticwiki generate -r ./my-project --full-local
+```
+
+There are two local backends:
+
+1. **Bundled inference (default)** — in-process llama.cpp via `node-llama-cpp`. No extra software; the model is downloaded automatically on first run.
+2. **Ollama** (`--use-ollama`) — use an [Ollama](https://ollama.com) server you already run, with any model it hosts.
+
+## Bundled Inference (default)
+
+On first run, SemanticWiki detects your hardware and downloads the bundled model:
+
+| | |
+|---|---|
+| Model | `gpt-oss-20b-semanticwiki` — a GPT-OSS 20B fine-tune for architectural wiki generation |
+| Format / size | Q8 GGUF, ~22.3 GB (one-time download) |
+| Recommended hardware | 24 GB VRAM (GPU) or 32 GB RAM (CPU/Apple Silicon unified memory) |
+| Context window | 32,768 tokens |
+| Cache location | `~/.semanticwiki/models/` |
+
+GPU support (CUDA, Metal, Vulkan) is auto-detected. Check what local mode will do before committing to a run:
+
+```bash
+semanticwiki generate -r ./my-project --full-local --estimate
+```
+
+This prints detected hardware, the recommended model, whether it's already downloaded, and estimated indexing/generation time and disk usage.
+
+### Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--local-model <model>` | Model ID from the registry | auto-selected for your hardware |
+| `--model-path <path>` | Use a specific GGUF file instead of the registry | — |
+| `--gpu-layers <n>` | Layers to offload to GPU | auto |
+| `--context-size <n>` | Context window size | `32768` |
+| `--threads <n>` | CPU threads for inference | auto |
+
+## Ollama Backend
+
+If you already run Ollama and prefer managing models yourself:
+
+```bash
+ollama pull qwen2.5-coder:14b
+semanticwiki generate -r ./my-project --full-local --use-ollama
+
+# Custom host and model
+semanticwiki generate -r ./my-project --full-local --use-ollama \
+  --ollama-host http://192.168.1.50:11434 --local-model codestral:22b
+```
+
+The default Ollama model is `qwen2.5-coder:14b`. Any Ollama model with tool-calling support should work; coder-tuned models give the best results.
+
+## Expectations vs Cloud Modes
+
+Local generation is slower than the cloud modes and quality depends on the model and hardware. Rough guidance:
+
+| | Cloud (`--direct-api`) | Local (GPU) | Local (CPU) |
+|---|---|---|---|
+| Small repo (<500 files) | minutes | ~10–20 min | ~30–60 min |
+| Large repo (2000+ files) | ~30 min | hours | many hours |
+| Cost | API charges | free | free |
+| Privacy | cloud | 100% local | 100% local |
+
+For large repos, combine local mode with `--max-chunks` and `-p/--path` to bound the work.
+
+## Troubleshooting
+
+**Model download fails or is interrupted** — re-run the command (the download restarts), or download manually:
+
+```bash
+mkdir -p ~/.semanticwiki/models
+wget -O ~/.semanticwiki/models/gpt-oss-20b-semanticwiki-q8_0.gguf \
+  "https://huggingface.co/GhostScientist/gpt-oss-20b-semanticwiki-gguf/resolve/main/gpt-oss-20b-semanticwiki-q8_0.gguf"
+```
+
+**Out of memory** — reduce the context window or GPU offload, or limit indexing:
+
+```bash
+semanticwiki generate -r <repo> --full-local --context-size 16384
+semanticwiki generate -r <repo> --full-local --gpu-layers 20
+semanticwiki generate -r <repo> --full-local --max-chunks 2000
+```
+
+If your machine can't fit the bundled 20B model, use `--use-ollama` with a smaller model (e.g. `qwen2.5-coder:7b`).
+
+**Slow performance** — run with `--verbose` to confirm the GPU is being used; try forcing more GPU layers with `--gpu-layers 40`.
+
+**Cannot connect to Ollama** — make sure `ollama serve` is running, or drop `--use-ollama` to use bundled inference instead.
+
+## See Also
+
+- [Local mode test repositories](./LOCAL_ONLY_TESTING.md) — repos of varying sizes/stacks for exercising local mode (maintainer testing guide)
+- [Original design plan](./plans/LOCAL_MODE_PLAN.md) — historical

--- a/docs/plans/LOCAL_MODE_PLAN.md
+++ b/docs/plans/LOCAL_MODE_PLAN.md
@@ -1,5 +1,7 @@
 # Local Mode Implementation Plan
 
+> **Status: Implemented** (v1.2.x). This is the original design document, kept for historical reference — some details have since changed. In particular, the bundled model registry now ships the `gpt-oss-20b-semanticwiki` fine-tune rather than the Qwen 2.5 Coder family described below. For current, user-facing local mode documentation see [`docs/local-mode.md`](../local-mode.md). Remaining unshipped items from "Future Enhancements" are tracked in [`ROADMAP.md`](./ROADMAP.md).
+
 ## Overview
 
 This document outlines the implementation plan for adding a `--full-local` flag to the `semanticwiki generate` command, enabling complete offline operation using local language models with **zero external dependencies**.


### PR DESCRIPTION
- Rewrite README for accuracy against the current CLI:
  - Add a prominent 'Choose Your Mode' section covering Claude Code
    (default), --direct-api, and --full-local, so users know they can
    run with API credits or fully locally with no key
  - Fix stale flags: search (-o/--mode/--code, not -w/--hybrid),
    mcp-server (-o, not -w), pack (-f for output file), unpack
    (positional package arg), default model (claude-sonnet-5)
  - Document previously missing commands: verify, update-embeddings,
    update-wiki, config, and the default coding-assistant form
  - Correct static site output location (sibling site/ dir) and
    embedding model (BGE-small-en-v1.5)
- Add docs/local-mode.md: user-facing local mode guide (bundled
  gpt-oss-20b-semanticwiki model, hardware requirements, Ollama
  backend, tuning flags, troubleshooting)
- Slim docs/LOCAL_ONLY_TESTING.md into a maintainer testing guide and
  remove stale Qwen bundled-model references
- Add docs/README.md index; mark LOCAL_MODE_PLAN.md as implemented and
  historical

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T3x83mJ2i475xGECMps94w